### PR TITLE
Add entries in bulk

### DIFF
--- a/app/src/main/res/layout/fragment_entry_long_press.xml
+++ b/app/src/main/res/layout/fragment_entry_long_press.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/listSpacing"
+    android:background="@color/colorLightBackground"
+    android:orientation="horizontal">
+
+    <LinearLayout
+        android:layout_margin="10dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:id="@+id/draggableArea"
+        android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilQuantity"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tietQuantity"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Quantity"
+                android:inputType="number" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -56,4 +56,8 @@
     <string name="display_interval">Intervalo a mostrar</string>
     <string name="goal">Objetivo</string>
     <string name="tutorial_change_graph_interval">Pulsar para cambiar el intervalo de tiempo</string>
+    <string name="accept">Aceptar</string>
+    <string name="titleDialogConfirmation">¿Borrar entradas?</string>
+    <string name="confirmation_message">¿Estás seguro de que quieres eliminar %1$d entradas?\n\nEsta acción podría tomar un momento.</string>
+    <string name="yes">Sí</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,4 +56,9 @@
     <string name="color_hint">Color %1$d</string>
     <string name="display_interval">Interval to display</string>
     <string name="goal">Goal</string>
+    <string name="accept">Accept</string>
+    <string name="titleDialogConfirmation">Delete entries?</string>
+    <string name="confirmation_message">Are you sure you want to delete %1$d entries?\n\n
+        This action may take a moment.</string>
+    <string name="yes">Yes</string>
 </resources>


### PR DESCRIPTION
Hi, I made some changes to add a lot of entries in a row without pressing increase/decrease button for each one.
I make this because when you have to add so much, it takes some time of you pressing that button. Now you can do it by typing how many you want to add.

When you want to add/delete a lot of them it will take a moment to finish that task.

### Changes:
##### ViewModel:

- Added a mutex variable.
- decrementCounter(name: String, mode: Boolean)
    - Mutex to prevent concurrency problems.
    - mode: when is true it will show the undo message of observer.onCounterDecremented(). When is false it won't show that message.

- deleteCounter(name: String)
    - Added mutex to prevent a crash when a counter is incrementing/decrementing and delete the same counter.

##### EntryViewHolder:
- Added a new function: dialog()
    - This function is to show the view where you put how many entries you want to add in a row. Then it shows a confirmation view before starting the task.
- Long click listener: added for decrease button and modified increase
    button.

##### fragment_entry_long_press:
- To make the dialog to put the quantity to increase or decrease a counter. This only shows when long pressing increase/decrease button.

##### Strings:
- Added some for english and spanish.

### Preview
https://github.com/user-attachments/assets/a05d6352-7a49-413d-a362-2c80ea8fdb8a


