### PR TITLE
Introduce haptic feedback

### DIFF
--- a/app/src/main/java/org/kde/bettercounter/persistence/Repository.kt
+++ b/app/src/main/java/org/kde/bettercounter/persistence/Repository.kt
@@ -17,6 +17,7 @@ const val COUNTERS_COLOR_PREFS_KEY = "color.%s"
 const val COUNTERS_GOAL_PREFS_KEY = "goal.%s"
 const val TUTORIALS_PREFS_KEY = "tutorials"
 const val AUTO_EXPORT_ENABLED_KEY = "auto_export_enabled"
+const val HAPTIC_FEEDBACK_ENABLED_KEY = "haptic_feedback_enabled"
 const val AVERAGE_CALCULATION_MODE_KEY = "average_calculation_mode"
 const val AUTO_EXPORT_FILE_URI_KEY = "auto_export_file_uri"
 
@@ -153,7 +154,7 @@ class Repository(
     fun setAutoExportOnSave(enabled: Boolean) {
         sharedPref.edit { putBoolean(AUTO_EXPORT_ENABLED_KEY, enabled) }
     }
-    
+
     fun getAutoExportFileUri(): String? {
         return sharedPref.getString(AUTO_EXPORT_FILE_URI_KEY, null)
     }
@@ -161,7 +162,16 @@ class Repository(
     fun setAutoExportFileUri(uriString: String) {
         sharedPref.edit { putString(AUTO_EXPORT_FILE_URI_KEY, uriString) }
     }
-    
+
+    fun isHapticFeedbackEnabled(): Boolean {
+        return sharedPref.getBoolean(HAPTIC_FEEDBACK_ENABLED_KEY, false)
+    }
+
+    fun setHapticFeedback(enabled: Boolean) {
+        sharedPref.edit { putBoolean(HAPTIC_FEEDBACK_ENABLED_KEY, enabled) }
+    }
+
+
     fun getAverageCalculationMode(): AverageMode {
         val ordinal = sharedPref.getInt(AVERAGE_CALCULATION_MODE_KEY, AverageMode.FIRST_TO_LAST.ordinal)
         return AverageMode.entries[ordinal]

--- a/app/src/main/java/org/kde/bettercounter/persistence/Repository.kt
+++ b/app/src/main/java/org/kde/bettercounter/persistence/Repository.kt
@@ -154,7 +154,7 @@ class Repository(
     fun setAutoExportOnSave(enabled: Boolean) {
         sharedPref.edit { putBoolean(AUTO_EXPORT_ENABLED_KEY, enabled) }
     }
-
+    
     fun getAutoExportFileUri(): String? {
         return sharedPref.getString(AUTO_EXPORT_FILE_URI_KEY, null)
     }

--- a/app/src/main/java/org/kde/bettercounter/ui/main/EntryViewHolder.kt
+++ b/app/src/main/java/org/kde/bettercounter/ui/main/EntryViewHolder.kt
@@ -23,6 +23,7 @@ class EntryViewHolder(
 
     fun onBind(counter: CounterSummary) {
         binding.root.setBackgroundColor(counter.color.colorInt)
+        val isHapticFeebdackEnabled = viewModel.isHapticFeedbackEnabled()
         val rippleRes = CounterColors.getInstance(activity).getRippleDrawableRes(counter.color)
         if (rippleRes != null) {
             binding.increaseButton.setBackgroundResource(rippleRes)
@@ -33,6 +34,11 @@ class EntryViewHolder(
         }
         binding.increaseButton.setOnClickListener {
             viewModel.incrementCounter(counter.name)
+
+            if (isHapticFeedbackEnabled) {
+                binding.root.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+            }
+
             if (!viewModel.isTutorialShown(Tutorial.PICK_DATE)) {
                 viewModel.setTutorialShown(Tutorial.PICK_DATE)
                 showPickDateTutorial()
@@ -41,10 +47,20 @@ class EntryViewHolder(
         binding.increaseButton.setOnLongClickListener {
             showDateTimePicker(activity, Calendar.getInstance()) { pickedDateTime ->
                 viewModel.incrementCounter(counter.name, pickedDateTime.time)
+
+                if (isHapticFeedbackEnabled) {
+                    binding.root.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                }
             }
             true
         }
-        binding.decreaseButton.setOnClickListener { viewModel.decrementCounter(counter.name) }
+        binding.decreaseButton.setOnClickListener {
+            viewModel.decrementCounter(counter.name)
+
+            if (isHapticFeedbackEnabled) {
+                binding.root.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+            }
+        }
         binding.draggableArea.setOnClickListener { onClickListener(counter) }
         binding.draggableArea.setOnLongClickListener {
             if (!canDrag()) return@setOnLongClickListener false

--- a/app/src/main/java/org/kde/bettercounter/ui/main/MainActivityViewModel.kt
+++ b/app/src/main/java/org/kde/bettercounter/ui/main/MainActivityViewModel.kt
@@ -157,6 +157,10 @@ class MainActivityViewModel(val application: Application) {
         return tutorialsShown.contains(id.name)
     }
 
+    fun isHapticFeedbackEnabled(): Boolean {
+        return repo.isHapticFeedbackEnabled()
+    }
+
     fun editCounterSameName(counterMetadata: CounterMetadata) {
         val name = counterMetadata.name
         repo.setCounterMetadata(counterMetadata)

--- a/app/src/main/java/org/kde/bettercounter/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/org/kde/bettercounter/ui/settings/SettingsActivity.kt
@@ -53,6 +53,12 @@ class SettingsActivity : AppCompatActivity() {
         }
         updateAutoExportFileButtonVisibility(binding.switchAutoExport.isChecked)
 
+        // Haptic feedback
+        binding.switchHapticFeedback.isChecked = viewModel.isHapticFeedbackEnabled()
+        binding.switchHapticFeedback.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.setHapticFeedback(isChecked)
+        }
+
         // First hour of day
         binding.buttonChangeFirstHourOfDay.setOnClickListener {
             var currentSelection = FirstHourOfDay.get()

--- a/app/src/main/java/org/kde/bettercounter/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/kde/bettercounter/ui/settings/SettingsViewModel.kt
@@ -24,6 +24,14 @@ class SettingsViewModel(application: Application) {
         repo.setAutoExportFileUri(uriString)
     }
 
+    fun isHapticFeedbackEnabled(): Boolean {
+        return repo.isHapticFeedbackEnabled()
+    }
+
+    fun setHapticFeedback(enabled: Boolean) {
+        repo.setHapticFeedback(enabled)
+    }
+
     fun getAverageCalculationMode(): AverageMode {
         return repo.getAverageCalculationMode()
     }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -36,6 +36,19 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:text="@string/behavior_settings"
+                android:textAppearance="?attr/textAppearanceHeadline6" 
+                android:layout_marginBottom="8dp" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switchHapticFeedback"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/haptic_feedback" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:text="@string/export_settings"
                 android:textAppearance="?attr/textAppearanceHeadline6"
                 android:layout_marginBottom="8dp" />

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -64,6 +64,8 @@
     <string name="auto_export">Exporta automàticament quan canviï un comptador</string>
     <string name="current_export_file">Els comptadors s\'exportaran automàticament a %1$s</string>
     <string name="export_disabled">Sempre podeu exportar els comptadors manualment des del menú contextual de la pantalla principal.</string>
+    <string name="haptic_feedback">Resposta hàptica</string>
+    <string name="behavior_settings">Comportament</string>
     <string name="change_button">Canvia</string>
     <string name="export_error">Error en exportar</string>
     <string name="average_calculation_settings">Càlcul de la mitjana</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -63,6 +63,8 @@
     <string name="auto_export">Eksporter automatisk når en tæller ændres</string>
     <string name="current_export_file">Tællere vil automatisk blive eksporteret til %1$s</string>
     <string name="export_disabled">Du kan altid eksportere tællere manuelt fra hovedskærmens kontekstmenu.</string>
+    <string name="haptic_feedback">Haptisk feedback</string>
+    <string name="behavior_settings">Adfærd</string>
     <string name="change_button">Skift</string>
     <string name="export_error">Eksport mislykkedes</string>
     <string name="average_calculation_settings">Gennemsnitsberegning</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -63,6 +63,8 @@
     <string name="auto_export">Automatisch exportieren, wenn sich ein Zähler ändert</string>
     <string name="current_export_file">Zähler werden automatisch nach %1$s exportiert</string>
     <string name="export_disabled">Sie können die Zähler jederzeit manuell über das Kontextmenü des Hauptbildschirms exportieren.</string>
+    <string name="haptic_feedback">Haptisches Feedback</string>
+    <string name="behavior_settings">Verhalten</string>
     <string name="change_button">Ändern</string>
     <string name="export_error">Export fehlgeschlagen</string>
     <string name="average_calculation_settings">Durchschnittsberechnung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -64,6 +64,8 @@
     <string name="auto_export">Exportar automáticamente cuando cambie un contador</string>
     <string name="current_export_file">Los contadores se exportarán automáticamente a %1$s</string>
     <string name="export_disabled">Siempre puedes exportar los contadores manualmente desde el menú contextual de la pantalla principal.</string>
+    <string name="haptic_feedback">Respuesta háptica</string>
+    <string name="behavior_settings">Comportamiento</string>
     <string name="change_button">Cambiar</string>
     <string name="export_error">Error al exportar</string>
     <string name="average_calculation_settings">Cálculo de la media</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -64,6 +64,8 @@
     <string name="auto_export">Exporter automatiquement lors d\'un changement de compteur</string>
     <string name="current_export_file">Les compteurs seront exportés automatiquement vers %1$s</string>
     <string name="export_disabled">Vous pouvez toujours exporter les compteurs manuellement depuis le menu contextuel de l\'écran principal.</string>
+    <string name="haptic_feedback">Retour haptique</string>
+    <string name="behavior_settings">Comportement</string>
     <string name="change_button">Changer</string>
     <string name="export_error">Échec de l\'exportation</string>
     <string name="average_calculation_settings">Calcul de la moyenne</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -64,6 +64,8 @@
     <string name="auto_export">Автоматически экспортировать при изменении счетчика</string>
     <string name="current_export_file">Счетчики будут автоматически экспортированы в %1$s</string>
     <string name="export_disabled">Вы всегда можете экспортировать счетчики вручную из контекстного меню главного экрана.</string>
+    <string name="haptic_feedback">Тактильная отдача</string>
+    <string name="behavior_settings">Поведение</string>
     <string name="change_button">Изменить</string>
     <string name="export_error">Ошибка экспорта</string>
     <string name="average_calculation_settings">Расчет среднего значения</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -63,6 +63,8 @@
     <string name="auto_export">Bir sayaç değiştiğinde otomatik olarak dışa aktar</string>
     <string name="current_export_file">Sayaçlar otomatik olarak %1$s konumuna dışa aktarılacak</string>
     <string name="export_disabled">Sayaçları her zaman ana ekran bağlam menüsünden manuel olarak dışa aktarabilirsiniz.</string>
+    <string name="haptic_feedback">Dokunsal geri bildirim</string>
+    <string name="behavior_settings">Davranış</string>
     <string name="change_button">Değiştir</string>
     <string name="export_error">Dışa aktarma başarısız</string>
     <string name="average_calculation_settings">Ortalama hesaplama</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -62,6 +62,8 @@
     <string name="auto_export">计数器变更时自动导出</string>
     <string name="current_export_file">计数器将自动导出到 %1$s</string>
     <string name="export_disabled">您随时可以从主屏幕的上下文菜单手动导出计数器。</string>
+    <string name="haptic_feedback">触觉反馈</string>
+    <string name="behavior_settings">行为</string>
     <string name="change_button">更改</string>
     <string name="export_error">导出失败</string>
     <string name="average_calculation_settings">平均值计算</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,8 @@
     <string name="auto_export">Auto-export when a counter changes</string>
     <string name="current_export_file">Counters will be exported automatically to %1$s</string>
     <string name="export_disabled">You can always export the counters manually from the main screen\'s context menu.</string>
+    <string name="haptic_feedback">Haptic Feedback</string>
+    <string name="behavior_settings">Behavior</string>
     <string name="change_button">Change</string>
     <string name="export_error">Export failed</string>
     <string name="average_calculation_settings">Average Calculation</string>


### PR DESCRIPTION
Hi!
I added a setting to enable haptic feedback every time you increased or decreased a counter.

## Context

I use the BetterCounter for knitting, more specifically for counting my rows. It happened to me some times, that I pressed too long, or moved away from the button, so the button did not actually trigger without me noticing.
Then, when I noticed, that I sometimes missed it, I became paranoid about whether I pressed. Increasing a row sometimes happens within a minute, so sadly the time display alone won't help.
Having haptic confirmation would help me a lot, I think.

## Changes

- I added an entry "isHapticFeedbackEnabled" to the Repository to store the setting.
- I addded the respective switch to the settings activity in a new section "Behavior".
- The switch default setting is "off", therefore the default behavior doesn't change.
- I added the haptic feedback in the EntryViewHolder. I'm unsure, whether this is the right place, as most logic happens in the MainActivity, but felt this was more UI-related and therefore it might be good here.

## Disclaimer

I am not confident in Java and/or Kotlin, so if I'm missing conventions, I'm happy to learn. 
No code was AI-generated\*, so all mistakes belong to me.

\*Translations aside from German and English were made by ChatGPT.