### PR TITLE
[feat] Display the date of first occurence

### DIFF
--- a/app/src/main/java/org/kde/bettercounter/ui/chart/ChartHolder.kt
+++ b/app/src/main/java/org/kde/bettercounter/ui/chart/ChartHolder.kt
@@ -90,9 +90,10 @@ class ChartHolder(
         val averageMode = viewModel.getAverageCalculationMode()
         val periodAverage = getPeriodAverageString(counter, intervalEntries, rangeStart, rangeEnd, averageMode)
         val lifetimeAverage = getLifetimeAverageString(counter, averageMode)
-        binding.chartAverage.text = activity.getString(R.string.stats_averages, periodAverage, lifetimeAverage)
+        val firstDataDate = counter.leastRecent
+        binding.chartAverage.text = activity.getString(R.string.stats_averages, periodAverage, lifetimeAverage, firstDataDate)
         if (binding.chartAverage.lineCount > 1) {
-            binding.chartAverage.text = activity.getString(R.string.stats_averages_multiline, periodAverage, lifetimeAverage)
+            binding.chartAverage.text = activity.getString(R.string.stats_averages_multiline, periodAverage, lifetimeAverage, firstDataDate)
         }
 
         // Goal stats

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,8 +27,8 @@
     <string name="just_now">A l\'instant</string>
     <string name="goal_stats_averages">Objectif atteint: %1$s, vie entière: %2$s</string>
     <string name="goal_stats_lifetime_averages">Objectif vie entière atteint: %1$s</string>
-    <string name="stats_averages">Moyenne: %1$s, vie entière: %2$s</string>
-    <string name="stats_averages_multiline">Moyenne: %1$s\nVie entière: %2$s</string>
+    <string name="stats_averages">Moyenne: %1$s, vie entière: %2$s, première entrée: %3$s</string>
+    <string name="stats_averages_multiline">Moyenne: %1$s\nVie entière: %2$s\nPremière entrée: %3$s</string>
     <string name="stats_average_per_hour">%1$.2f fois par heure</string>
     <string name="stats_average_every_hours">toutes les %1$.2f heures</string>
     <string name="stats_average_per_day">%1$.2f fois par jour</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,8 +27,8 @@
     <string name="just_now">Just now</string>
     <string name="goal_stats_averages">Goal reached: %1$s, lifetime: %2$s</string>
     <string name="goal_stats_lifetime_averages">Lifetime goal reached: %1$s</string>
-    <string name="stats_averages">Avg: %1$s, lifetime: %2$s</string>
-    <string name="stats_averages_multiline">Avg: %1$s\nLifetime: %2$s</string>
+    <string name="stats_averages">Avg: %1$s, lifetime: %2$s, first data: %3$s</string>
+    <string name="stats_averages_multiline">Avg: %1$s\nLifetime: %2$s\nFirst data: %3$s</string>
     <string name="stats_average_per_hour">%1$.2f times/hour</string>
     <string name="stats_average_every_hours">every %1$.2f hours</string>
     <string name="stats_average_per_day">%1$.2f times/day</string>


### PR DESCRIPTION
Hi, 

I tried to hack a bit the app to be able to display the date of first occurrence of a data in a counter: it's often useful for me to properly analyze the data (e.g. why do I have so few occurrences of this counter in March?! Ah.. I started to count that in 15th of March...)

I don't know how you handle evolution of translations through time in the app: maybe it would be better to create new translation keys since I added a new param, since I can't properly transform all existing translations? 

Also I'm not super happy of just displaying the date, I guess I should call some helper to format it properly, but idk if there's a lib for it already or if I should just use some standard formatter? (not used to hack android apps :)) 